### PR TITLE
Fix dead link to the Scorekeeper manual, again

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ To launch, extract the zip and open the `FTCLauncher` file on macOS/Linux or the
 
 ## Documentation
 
-The user documentation can be found here: [FTC Scorekeeper Manual](https://ftc-resources.firstinspires.org/ftc/volunteer/lead-scorekeeper).
+Information about the (Lead) Scorekeeper role and responsibilitie can be found in the [FTC Scorekeeper Manual](https://ftc-resources.firstinspires.org/ftc/volunteer/lead-scorekeeper).
+Instructions for setting up and operating FTC-Live are available in the [FTC-Live Setup Guide](https://ftc-resources.firstinspires.org/ftc/event/scoring-setup).
 
 ## Reporting Issues
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To launch, extract the zip and open the `FTCLauncher` file on macOS/Linux or the
 
 ## Documentation
 
-The user documentation can be found here: [FTC Scorekeeper Manual](https://www.firstinspires.org/sites/default/files/uploads/resource_library/ftc/scorekeeper-manual.pdf).
+The user documentation can be found here: [FTC Scorekeeper Manual](https://ftc-resources.firstinspires.org/ftc/volunteer/lead-scorekeeper).
 
 ## Reporting Issues
 


### PR DESCRIPTION
new year, new website, new dead link

Hopefully this one is a little longer-lasting 😄 

Also added a link to the [FTC-Live Setup Guide](https://ftc-resources.firstinspires.org/ftc/event/scoring-setup).